### PR TITLE
Load different clip models, jit option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 *.m~
 .vs
 results/
+slurm/
+docs/
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 results/
 slurm/
 docs/
-
+.vscode/
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/main.py
+++ b/main.py
@@ -178,7 +178,7 @@ def run_branched(args):
                                                                 std=args.frontview_std,
                                                                 return_views=True,
                                                                 background=background)
-        # rendered_images = preprocess(rendered_images)
+        rendered_images = preprocess(transforms.ToPILImage(rendered_images))
     
         if n_augs == 0:
             clip_image = clip_transform(rendered_images)

--- a/main.py
+++ b/main.py
@@ -178,7 +178,7 @@ def run_branched(args):
                                                                 std=args.frontview_std,
                                                                 return_views=True,
                                                                 background=background)
-        rendered_images = preprocess(transforms.ToPILImage(rendered_images))
+        rendered_images = preprocess(transforms.ToPILImage()(rendered_images))
     
         if n_augs == 0:
             clip_image = clip_transform(rendered_images)

--- a/main.py
+++ b/main.py
@@ -37,6 +37,12 @@ def run_branched(args):
     res = 224 
     if args.clipmodel == "ViT-L/14@336px":
         res = 336
+    if args.clipmodel == "RN50x4":
+        res = 288
+    if args.clipmodel == "RN50x16":
+        res = 384
+    if args.clipmodel == "RN50x64":
+        res = 448
         
     objbase, extension = os.path.splitext(os.path.basename(args.obj_path))
     # Check that isn't already done
@@ -178,7 +184,7 @@ def run_branched(args):
                                                                 std=args.frontview_std,
                                                                 return_views=True,
                                                                 background=background)
-        rendered_images = preprocess(transforms.ToPILImage()(rendered_images))
+        # rendered_images = torch.stack([preprocess(transforms.ToPILImage()(image)) for image in rendered_images])
     
         if n_augs == 0:
             clip_image = clip_transform(rendered_images)

--- a/main.py
+++ b/main.py
@@ -4,12 +4,10 @@ import kaolin.ops.mesh
 import kaolin as kal
 import torch
 from neural_style_field import NeuralStyleField
-from utils import device
+from utils import device 
 from render import Renderer
 from mesh import Mesh
-from utils import clip_model
 from Normalization import MeshNormalizer
-from utils import preprocess, add_vertices, sample_bary
 import numpy as np
 import random
 import copy
@@ -31,6 +29,9 @@ def run_branched(args):
     np.random.seed(args.seed)
     torch.backends.cudnn.benchmark = False
     torch.backends.cudnn.deterministic = True
+    
+    # Load CLIP model 
+    clip_model, preprocess = clip.load(args.clipmodel, device, jit=args.jit)
 
     objbase, extension = os.path.splitext(os.path.basename(args.obj_path))
     # Check that isn't already done
@@ -449,6 +450,7 @@ if __name__ == '__main__':
     parser.add_argument('--no_prompt', default=False, action='store_true')
     parser.add_argument('--exclude', type=int, default=0)
 
+    # Training settings 
     parser.add_argument('--frontview_std', type=float, default=8)
     parser.add_argument('--frontview_center', nargs=2, type=float, default=[0., 0.])
     parser.add_argument('--clipavg', type=str, default=None)
@@ -476,6 +478,10 @@ if __name__ == '__main__':
     parser.add_argument('--only_z', default=False, action='store_true')
     parser.add_argument('--standardize', default=False, action='store_true')
 
+    # CLIP model settings 
+    parser.add_argument('--clipmodel', type=str, default='VIT-B/32')
+    parser.add_argument('--jit', action="store_true")
+    
     args = parser.parse_args()
 
     run_branched(args)

--- a/main.py
+++ b/main.py
@@ -37,6 +37,7 @@ def run_branched(args):
     res = 224 
     if args.clipmodel == "ViT-L/14@336px":
         res = 336
+    print(res)
 
     objbase, extension = os.path.splitext(os.path.basename(args.obj_path))
     # Check that isn't already done

--- a/main.py
+++ b/main.py
@@ -178,7 +178,7 @@ def run_branched(args):
                                                                 std=args.frontview_std,
                                                                 return_views=True,
                                                                 background=background)
-        rendered_images = preprocess(rendered_images)
+        # rendered_images = preprocess(rendered_images)
     
         if n_augs == 0:
             clip_image = clip_transform(rendered_images)

--- a/main.py
+++ b/main.py
@@ -37,8 +37,7 @@ def run_branched(args):
     res = 224 
     if args.clipmodel == "ViT-L/14@336px":
         res = 336
-    print(res)
-
+        
     objbase, extension = os.path.splitext(os.path.basename(args.obj_path))
     # Check that isn't already done
     if (not args.overwrite) and os.path.exists(os.path.join(args.output_dir, "loss.png")) and \

--- a/main.py
+++ b/main.py
@@ -32,6 +32,11 @@ def run_branched(args):
     
     # Load CLIP model 
     clip_model, preprocess = clip.load(args.clipmodel, device, jit=args.jit)
+    
+    # Adjust output resolution depending on model type 
+    res = 224 
+    if args.clipmodel == "ViT-L/14@336px":
+        res = 336
 
     objbase, extension = os.path.splitext(os.path.basename(args.obj_path))
     # Check that isn't already done
@@ -52,7 +57,7 @@ def run_branched(args):
             except Exception as e:
                 print('Failed to delete %s. Reason: %s' % (file_path, e))
 
-    render = Renderer()
+    render = Renderer(dim=(res, res))
     mesh = Mesh(args.obj_path)
     MeshNormalizer(mesh)()
 
@@ -70,13 +75,13 @@ def run_branched(args):
     clip_normalizer = transforms.Normalize((0.48145466, 0.4578275, 0.40821073), (0.26862954, 0.26130258, 0.27577711))
     # CLIP Transform
     clip_transform = transforms.Compose([
-        transforms.Resize((224, 224)),
+        transforms.Resize((res, res)),
         clip_normalizer
     ])
 
     # Augmentation settings
     augment_transform = transforms.Compose([
-        transforms.RandomResizedCrop(224, scale=(1, 1)),
+        transforms.RandomResizedCrop(res, scale=(1, 1)),
         transforms.RandomPerspective(fill=1, p=0.8, distortion_scale=0.5),
         clip_normalizer
     ])
@@ -87,7 +92,7 @@ def run_branched(args):
     else:
         curcrop = args.normmaxcrop
     normaugment_transform = transforms.Compose([
-        transforms.RandomResizedCrop(224, scale=(curcrop, curcrop)),
+        transforms.RandomResizedCrop(res, scale=(curcrop, curcrop)),
         transforms.RandomPerspective(fill=1, p=0.8, distortion_scale=0.5),
         clip_normalizer
     ])
@@ -102,7 +107,7 @@ def run_branched(args):
 
     # Displacement-only augmentations
     displaugment_transform = transforms.Compose([
-        transforms.RandomResizedCrop(224, scale=(args.normmincrop, args.normmincrop)),
+        transforms.RandomResizedCrop(res, scale=(args.normmincrop, args.normmincrop)),
         transforms.RandomPerspective(fill=1, p=0.8, distortion_scale=0.5),
         clip_normalizer
     ])
@@ -185,7 +190,7 @@ def run_branched(args):
             curcrop += cropupdate
             # print(curcrop)
             normaugment_transform = transforms.Compose([
-                transforms.RandomResizedCrop(224, scale=(curcrop, curcrop)),
+                transforms.RandomResizedCrop(res, scale=(curcrop, curcrop)),
                 transforms.RandomPerspective(fill=1, p=0.8, distortion_scale=0.5),
                 clip_normalizer
             ])

--- a/main.py
+++ b/main.py
@@ -178,7 +178,8 @@ def run_branched(args):
                                                                 std=args.frontview_std,
                                                                 return_views=True,
                                                                 background=background)
-
+        rendered_images = preprocess(rendered_images)
+    
         if n_augs == 0:
             clip_image = clip_transform(rendered_images)
             encoded_renders = clip_model.encode_image(clip_image)

--- a/render.py
+++ b/render.py
@@ -266,9 +266,9 @@ class Renderer():
             masks.append(soft_mask)
 
             # Debugging: color where soft mask is 1
-            tmp_rgb = torch.ones((224, 224, 3))
-            tmp_rgb[torch.where(soft_mask.squeeze() == 1)] = torch.tensor([1, 0, 0]).float()
-            rgb_mask.append(tmp_rgb)
+            # tmp_rgb = torch.ones((224, 224, 3))
+            # tmp_rgb[torch.where(soft_mask.squeeze() == 1)] = torch.tensor([1, 0, 0]).float()
+            # rgb_mask.append(tmp_rgb)
 
             if background is not None:
                 image_features, mask = image_features
@@ -291,7 +291,7 @@ class Renderer():
 
         images = torch.cat(images, dim=0).permute(0, 3, 1, 2)
         masks = torch.cat(masks, dim=0)
-        rgb_mask = torch.cat(rgb_mask, dim=0)
+        # rgb_mask = torch.cat(rgb_mask, dim=0)
 
         if show:
             with torch.no_grad():

--- a/utils.py
+++ b/utils.py
@@ -5,25 +5,11 @@ import numpy as np
 from torchvision import transforms
 from pathlib import Path
 
-augment_transform = transforms.Compose([
-    transforms.RandomResizedCrop(224, scale=(0.1, 1)),
-    transforms.RandomPerspective(fill=0, p=1, distortion_scale=0.5),
-    # transforms.ColorJitter(hue=0.01, saturation=0.01),
-    transforms.Normalize((0.48145466, 0.4578275, 0.40821073), (0.26862954, 0.26130258, 0.27577711))
-])
-
-clip_transform = transforms.Compose([
-    transforms.Resize((224, 224)),
-    transforms.Normalize((0.48145466, 0.4578275, 0.40821073), (0.26862954, 0.26130258, 0.27577711))
-])
-
 if torch.cuda.is_available():
     device = torch.device("cuda:0")
     torch.cuda.set_device(device)
 else:
     device = torch.device("cpu")
-
-clip_model, preprocess = clip.load('ViT-B/32', device, jit=False)
 
 
 def get_camera_from_view(elev, azim, r=3.0):


### PR DESCRIPTION
Update parser options to take in any CLIP model + with JIT. The render image resolution is updated according to the model specifications. 
**Note:** as new CLIP models become public, for the sake of efficiency it will probably be good to just replace the render preprocessing (e.g. setting the render resolution) with the `preprocess` function given in the CLIP model loading. We can just set the default render resolution to be the current max of the models to prevent too much blurring from upsampling. 

Results shown on the ninja with each model with the same options + seed:
**RN50**
<img width="371" alt="Screen Shot 2022-08-26 at 12 00 09 PM" src="https://user-images.githubusercontent.com/29670153/186955934-f8adf855-f241-4f2b-ac65-3672830d4786.png">
**RN101**
<img width="371" alt="Screen Shot 2022-08-26 at 12 00 23 PM" src="https://user-images.githubusercontent.com/29670153/186955938-dfa743ea-00db-4c12-b372-89d1284cd24a.png">
**RN50x4**
<img width="371" alt="Screen Shot 2022-08-26 at 12 00 32 PM" src="https://user-images.githubusercontent.com/29670153/186955939-6cc1d916-4c82-4065-87b6-9fc305e333b0.png">
**RN50x16**
<img width="371" alt="Screen Shot 2022-08-26 at 12 00 47 PM" src="https://user-images.githubusercontent.com/29670153/186955940-a7f8d67c-d745-49ed-9304-dc1822b172d5.png">
**RN50x64**
<img width="371" alt="Screen Shot 2022-08-26 at 12 00 57 PM" src="https://user-images.githubusercontent.com/29670153/186955941-3375bdf4-fcf8-4b4e-b0d3-994b4f599dd4.png">
**VIT-B/32**
<img width="371" alt="Screen Shot 2022-08-26 at 12 01 08 PM" src="https://user-images.githubusercontent.com/29670153/186955944-e77f8cd7-ec0c-4de7-8d76-e57de012f702.png">
**VIT-B/16**
<img width="371" alt="Screen Shot 2022-08-26 at 12 01 16 PM" src="https://user-images.githubusercontent.com/29670153/186955947-b8f3c036-6b0b-4462-be49-aa15f396f3bb.png">
**VIT-L/14**
<img width="371" alt="Screen Shot 2022-08-26 at 12 01 24 PM" src="https://user-images.githubusercontent.com/29670153/186955948-a61ad9cc-e904-49f5-92ee-20baecdbc96f.png">
**VIT-L/14@336px**
<img width="371" alt="Screen Shot 2022-08-26 at 12 01 31 PM" src="https://user-images.githubusercontent.com/29670153/186955951-23f83bc3-41ef-4af0-9f5d-81a25cefeb62.png">
