### PR TITLE
Fix typo in main.py (introduced in #24)

### DIFF
--- a/main.py
+++ b/main.py
@@ -491,7 +491,7 @@ if __name__ == '__main__':
     parser.add_argument('--standardize', default=False, action='store_true')
 
     # CLIP model settings 
-    parser.add_argument('--clipmodel', type=str, default='VIT-B/32')
+    parser.add_argument('--clipmodel', type=str, default='ViT-B/32')
     parser.add_argument('--jit', action="store_true")
     
     args = parser.parse_args()


### PR DESCRIPTION
Running the demo scripts on a fresh clone of the repo throws an error:

```sh
(text2mesh) cpacker@...:text2mesh$ ./demo/run_alien_cobble.sh
Traceback (most recent call last):
  File "text2mesh/main.py", line 499, in <module>
    run_branched(args)
  File "text2mesh/main.py", line 34, in run_branched
    clip_model, preprocess = clip.load(args.clipmodel, device, jit=args.jit)
  File "anaconda3/envs/text2mesh/lib/python3.9/site-packages/clip/clip.py", line 124, in load
    raise RuntimeError(f"Model {name} not found; available models = {available_models()}")
RuntimeError: Model VIT-B/32 not found; available models = ['RN50', 'RN101', 'RN50x4', 'RN50x16', 'RN50x64', 'ViT-B/32', 'ViT-B/16', 'ViT-L/14', 'ViT-L/14@336px']
```

Seems like this is due to a typo [here](https://github.com/threedle/text2mesh/pull/24/files#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1R494), `VIT` should be `ViT`.

Same command post-fix:
```sh
(text2mesh) cpacker@...:text2mesh$ ./demo/run_alien_cobble.sh
ModuleList(
  (0): FourierFeatureTransform()
  (1): ProgressiveEncoding()
  (2): Linear(in_features=515, out_features=256, bias=True)
  (3): ReLU()
  (4): Linear(in_features=256, out_features=256, bias=True)
  (5): ReLU()
  (6): Linear(in_features=256, out_features=256, bias=True)
  (7): ReLU()
  (8): Linear(in_features=256, out_features=256, bias=True)
  (9): ReLU()
  (10): Linear(in_features=256, out_features=256, bias=True)
  (11): ReLU()
)
ModuleList(
  (0): Linear(in_features=256, out_features=256, bias=True)
  (1): ReLU()
  (2): Linear(in_features=256, out_features=256, bias=True)
  (3): ReLU()
  (4): Linear(in_features=256, out_features=3, bias=True)
)
ModuleList(
  (0): Linear(in_features=256, out_features=256, bias=True)
  (1): ReLU()
  (2): Linear(in_features=256, out_features=256, bias=True)
  (3): ReLU()
  (4): Linear(in_features=256, out_features=1, bias=True)
)
  0%|                                                                                                                                           | 0/1500 [00:00<?, ?it/s]
```